### PR TITLE
Fix progression and channel behavior

### DIFF
--- a/guardian/events.py
+++ b/guardian/events.py
@@ -104,8 +104,8 @@ async def on_reaction_add(reaction, user):
         else:
             bot.user_data[user.id]["chains_adopted"][chain_key] = 1
     
-    # Check role progression and announce in the reaction's channel
-    await check_role_progression(user, reaction.message.guild, reaction.message.channel)
+    # Check role progression and announce in the configured progression channel
+    await check_role_progression(user, reaction.message.guild)
 
 @bot.event
 async def on_message(message):


### PR DESCRIPTION
## Summary
- send role progression notifications in configured channel
- keep auto-registration messages in the quickstart channel

## Testing
- `python -m py_compile bot.py commands.py events.py utils.py`

------
https://chatgpt.com/codex/tasks/task_e_6843ad1d2594832881a6cbdaa26d12a7