### PR TITLE
Fix reaction chain tracking

### DIFF
--- a/guardian/commands.py
+++ b/guardian/commands.py
@@ -1025,7 +1025,7 @@ async def backfill_server(ctx, limit: int = None):
                         bot.user_data[user.id]["reaction_count"] += 1
                         
                         # Check for influence from reaction chains
-                        message_reactions = [str(r.emoji) for r in message.reactions]
+                        message_reactions = get_reaction_emojis(message)
                         if detect_starcode_chain(message_reactions):
                             influence = calculate_chain_influence(message_reactions, user.id, bot)
                             bot.user_data[user.id]["influence_score"] += influence
@@ -2302,7 +2302,7 @@ async def view_pending(ctx):
                     channel = ctx.guild.get_channel(data["channel_id"])
                     if channel:
                         message = await channel.fetch_message(msg_id)
-                        reactions = [str(r.emoji) for r in message.reactions if str(r.emoji) != "✨"]
+                        reactions = get_reaction_emojis(message)
                         if reactions:
                             chain_display = "".join(reactions)
                 except Exception:

--- a/guardian/events.py
+++ b/guardian/events.py
@@ -91,9 +91,8 @@ async def on_reaction_add(reaction, user):
     bot.user_data[user.id]["emojis_used"].add(emoji)
     bot.user_data[user.id]["reaction_count"] += 1
     
-    # Check for StarCode chains in message reactions
-    # Ignore the bot's own tracking reaction when evaluating the chain
-    message_reactions = [str(r.emoji) for r in reaction.message.reactions if str(r.emoji) != "✨"]
+    # Check for StarCode chains in message reactions, preserving duplicates
+    message_reactions = get_reaction_emojis(reaction.message)
 
     if detect_starcode_chain(message_reactions):
         # Calculate influence with reuse bonus
@@ -343,8 +342,8 @@ async def auto_register_reaction_chains():
             del bot.pending_reaction_chains[msg_id]
             continue
             
-        # Exclude the bot's sparkle indicator from the chain check
-        message_reactions = [str(r.emoji) for r in message.reactions if str(r.emoji) != "✨"]
+        # Get reaction emojis including duplicates and ignoring the sparkle indicator
+        message_reactions = get_reaction_emojis(message)
 
         if detect_starcode_chain(message_reactions):
             chain_key = "".join(message_reactions)

--- a/guardian/utils.py
+++ b/guardian/utils.py
@@ -64,6 +64,19 @@ def find_contiguous_emoji_chains(text):
         chains.append(current)
     return chains
 
+def get_reaction_emojis(message):
+    """Return a list of reaction emojis including duplicates.
+
+    The sparkle tracking reaction (✨) is ignored. This helper preserves the
+    count of each reaction so repeated emojis are considered part of the chain.
+    """
+    emojis = []
+    for reaction in message.reactions:
+        if str(reaction.emoji) == "✨":
+            continue
+        emojis.extend([str(reaction.emoji)] * reaction.count)
+    return emojis
+
 async def safe_add_roles(member, *roles):
     """Add roles while checking hierarchy and handling rate limits"""
     assignable = []


### PR DESCRIPTION
## Summary
- track reaction chains with duplicate emojis
- detect duplicates using new `get_reaction_emojis` helper
- display pending reaction chains using helper

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6843d6d33ca0832883b824c6643e02d0