### PR TITLE
Integrate local LLM mention replies

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Helmhud Guardian is a Discord bot. To run it you need Python 3.11+ and to instal
    python3 -m venv venv
    source venv/bin/activate
    ```
-2. Install requirements:
+2. Install requirements (includes LLM dependencies):
    ```bash
    pip install -r requirements.txt
    ```
@@ -18,5 +18,7 @@ Helmhud Guardian is a Discord bot. To run it you need Python 3.11+ and to instal
    ```bash
    python helmhud_guardian.py
    ```
+
+When running, mention `@Helmhud Guardian` in any channel to chat with the local LLM. The bot will reply using context from recent messages and influential memories.
 
 The bot stores its JSON data files in the directory specified by the `HELMHUD_DATA_DIR` environment variable. If not set, files are saved in the project root.

--- a/guardian/__init__.py
+++ b/guardian/__init__.py
@@ -2,5 +2,6 @@ from .bot import bot
 from . import utils  # noqa: F401
 from . import events  # noqa: F401
 from . import commands  # noqa: F401
+from . import llm  # noqa: F401
 
 __all__ = ["bot"]

--- a/guardian/events.py
+++ b/guardian/events.py
@@ -170,6 +170,32 @@ async def on_message(message):
 
         if await check_training_progress(message.author.id, "message", message.content, message.channel):
             await complete_training_quest(message.author, message.channel)
+
+    # LLM chat when the bot is mentioned
+    if bot.user in message.mentions:
+        query = message.clean_content.replace(bot.user.mention, "").strip()
+
+        # Gather recent context excluding the bot's own messages
+        recent_lines = []
+        async for m in message.channel.history(limit=5, before=message):
+            if m.author.bot:
+                continue
+            recent_lines.append(f"{m.author.display_name}: {m.clean_content}")
+        recent_lines.reverse()
+        recent_context = "\n".join(recent_lines)
+
+        from .llm import get_similar, generate_reply
+        memories = get_similar(query, k=5)
+        memory_block = "\n".join(memories)
+
+        prompt = (
+            "### Recent Conversation:\n" + recent_context +
+            "\n\n### Influential Memories:\n" + memory_block +
+            "\n\n### User Query:\n" + query
+        )
+        reply = await asyncio.to_thread(generate_reply, prompt)
+        await message.reply(reply)
+        return
     await bot.process_commands(message)
 
 async def complete_training_quest(user, channel):

--- a/guardian/llm.py
+++ b/guardian/llm.py
@@ -1,0 +1,70 @@
+"""Lightweight LLM interface for Helmhud Guardian."""
+
+from typing import List
+
+from transformers import AutoTokenizer, AutoModelForCausalLM
+from sentence_transformers import SentenceTransformer
+import faiss
+
+from .bot import bot
+
+MODEL_NAME = "mrfakename/Apriel-5B-Instruct-llamafied"
+EMB_MODEL_NAME = "all-MiniLM-L6-v2"
+
+_tokenizer = None
+_model = None
+_emb_model = None
+_index = None
+_memories: List[str] = []
+
+
+def _load_models():
+    global _tokenizer, _model, _emb_model
+    if _tokenizer is None:
+        _tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)
+    if _model is None:
+        _model = AutoModelForCausalLM.from_pretrained(
+            MODEL_NAME, device_map="auto", torch_dtype="auto"
+        )
+    if _emb_model is None:
+        _emb_model = SentenceTransformer(EMB_MODEL_NAME)
+
+
+def _build_index():
+    global _index, _memories
+    remories = []
+    for user in bot.user_data.values():
+        for r in user.get("remory_strings", []):
+            remories.append(r.get("context", ""))
+    if not remories:
+        _index = None
+        _memories = []
+        return
+    embeddings = _emb_model.encode(remories, convert_to_numpy=True)
+    _index = faiss.IndexFlatL2(embeddings.shape[1])
+    _index.add(embeddings)
+    _memories = remories
+
+
+def get_similar(text: str, k: int = 5) -> List[str]:
+    """Return up to k memory strings most similar to text."""
+    _load_models()
+    if _index is None:
+        _build_index()
+    if _index is None or not _memories:
+        return []
+    emb = _emb_model.encode([text], convert_to_numpy=True)
+    scores, idx = _index.search(emb, k)
+    results = []
+    for i in idx[0]:
+        if 0 <= i < len(_memories):
+            results.append(_memories[i])
+    return results
+
+
+def generate_reply(prompt: str, max_tokens: int = 300) -> str:
+    """Generate a reply from the LLM for a given prompt."""
+    _load_models()
+    inputs = _tokenizer(prompt, return_tensors="pt").to(_model.device)
+    output = _model.generate(**inputs, max_new_tokens=max_tokens)
+    return _tokenizer.decode(output[0], skip_special_tokens=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,7 @@ bleach
 Pillow
 python-magic
 emoji
+transformers
+accelerate
+sentence-transformers
+faiss-cpu


### PR DESCRIPTION
## Summary
- add lightweight LLM interface using transformers and FAISS
- reply with LLM when the bot is mentioned
- wire new module into package init
- document new dependencies and usage
- update requirements with LLM packages

## Testing
- `python -m py_compile guardian/*.py helmhud_guardian.py`

------
https://chatgpt.com/codex/tasks/task_e_6844858839c88328a19110b8b338fd4d